### PR TITLE
modify opacity of disabled buttons in the toolbar

### DIFF
--- a/oerpub/css/toolbar.css
+++ b/oerpub/css/toolbar.css
@@ -79,6 +79,9 @@ figure figcaption::before {
 .toolbar .btn-toolbar {
   margin: 3px 0;
 }
+.toolbar .btn[disabled] {
+  opacity: .3;
+}
 .toolbar .btn-group > .btn + .dropdown-toggle {
   height: 37px;
   width: 20px;


### PR DESCRIPTION
http://redmine.oerpub.org/issues/159

note that this modifies the opacity for all disabled buttons in the toolbar, not just the indent lists. so take a look at the other things in the toolbar as well, if we want to restrict the change to just the indent buttons thats not hugely more complicated.
