### PR TITLE
override default bootstrap styles for code blocks - make no-wrap with scroll bar

### DIFF
--- a/oerpub/css/html5_content_in_oerpub.css
+++ b/oerpub/css/html5_content_in_oerpub.css
@@ -176,6 +176,11 @@ div.code{
   margin: 1em 0;
 }
 
+pre {
+  white-space: nowrap;
+  overflow-y: scroll;
+}
+
 pre.codeblock{
   margin: 0;
   text-align: left;


### PR DESCRIPTION
http://redmine.oerpub.org/issues/187

originally I wanted to change the editor to use `<code>` instead of `<pre>` or at least add another class to the `<pre>` tags to select on in the css, but couldn't figure out the aloha plugin system where all that was happening, so I just overrode all the `<pre>` styles instead.

theoretically this solution should work fine anyway, since by bootstrap convention `<pre>` is only used for code blocks anyway, but I'd still love an explanation as to how I could have accomplished the other approach just for my own education.
