### PR TITLE
Ephemera nested wrap

### DIFF
--- a/src/lib/aloha/ephemera.js
+++ b/src/lib/aloha/ephemera.js
@@ -396,7 +396,9 @@ define([
 
 			// Ephemera.markWrapper() and Ephemera.markFiller()
 			if (-1 !== Arrays.indexOf(classes, 'aloha-ephemera-wrapper') || -1 !== Arrays.indexOf(classes, 'aloha-ephemera-filler')) {
-				Dom.moveNextAll(elem.parentNode, elem.firstChild, elem.nextSibling);
+				if (elem.parentNode) {
+					Dom.moveNextAll(elem.parentNode, elem.firstChild, elem.nextSibling);
+				}
 				$.removeData(elem);
 				return false;
 			}

--- a/src/plugins/oer/note/lib/note-plugin.coffee
+++ b/src/plugins/oer/note/lib/note-plugin.coffee
@@ -44,7 +44,7 @@ define [
 		# Move all the other children into an editable body div
 		$body = $note.find('.body')
 		if not $body[0]
-			$body = jQuery('<div class="body"></div>')
+			$body = jQuery('<div class="body aloha-ephemera-wrapper"></div>')
 			# Fill the new body element with the original children
 			$note.children().not($title).appendTo $body
 		# Mark that the body div should be unwrapped

--- a/src/plugins/oer/note/lib/note-plugin.js
+++ b/src/plugins/oer/note/lib/note-plugin.js
@@ -24,7 +24,7 @@
       }
       $body = $note.find('.body');
       if (!$body[0]) {
-        $body = jQuery('<div class="body"></div>');
+        $body = jQuery('<div class="body aloha-ephemera-wrapper"></div>');
         $note.children().not($title).appendTo($body);
       }
       $body.appendTo($note);


### PR DESCRIPTION
The body `<div/>` in a note is a separate editable but should be unwrapped when serializing.

The `ephemera-wrapped` class now works on nested editables.
