### PR TITLE
Only turn first nested title div into a title editor.

### DIFF
--- a/src/plugins/oer/title/lib/title-plugin.coffee
+++ b/src/plugins/oer/title/lib/title-plugin.coffee
@@ -31,13 +31,14 @@ define [
       # Add a prune function that cleans up the title editor
       emap = Ephemera.ephemera().pruneFns.push (node) ->
         $node = $(node)
-        if $node.is('div.title')
+        if $node.is('div.title') and $node.has('.title-editor')
           $node.text($node.find('.title-editor').text())
           return $node.get(0)
         node
 
       Aloha.bind 'aloha-editable-created', ($event, editable) ->
-        editable.obj.find('div.title:not(.aloha-block)').alohaBlock('aloha-block-type': 'TitleBlock')
+        # Turn the first directly nested title div into a title editor
+        editable.obj.find('> div.title:not(.aloha-block)').alohaBlock('aloha-block-type': 'TitleBlock')
         if editable.obj.is('.title-editor')
           # Glue key handler to title editor. Remove the old handler, this
           # editor does not care for all those other handlers

--- a/src/plugins/oer/title/lib/title-plugin.coffee
+++ b/src/plugins/oer/title/lib/title-plugin.coffee
@@ -31,7 +31,7 @@ define [
       # Add a prune function that cleans up the title editor
       emap = Ephemera.ephemera().pruneFns.push (node) ->
         $node = $(node)
-        if $node.is('div.title') and $node.has('.title-editor')
+        if $node.is('div.title') and $node.has('.title-editor').length
           $node.text($node.find('.title-editor').text())
           return $node.get(0)
         node

--- a/src/plugins/oer/title/lib/title-plugin.js
+++ b/src/plugins/oer/title/lib/title-plugin.js
@@ -22,7 +22,7 @@
         emap = Ephemera.ephemera().pruneFns.push(function(node) {
           var $node;
           $node = $(node);
-          if ($node.is('div.title') && $node.has('.title-editor')) {
+          if ($node.is('div.title') && $node.has('.title-editor').length) {
             $node.text($node.find('.title-editor').text());
             return $node.get(0);
           }

--- a/src/plugins/oer/title/lib/title-plugin.js
+++ b/src/plugins/oer/title/lib/title-plugin.js
@@ -22,14 +22,14 @@
         emap = Ephemera.ephemera().pruneFns.push(function(node) {
           var $node;
           $node = $(node);
-          if ($node.is('div.title')) {
+          if ($node.is('div.title') && $node.has('.title-editor')) {
             $node.text($node.find('.title-editor').text());
             return $node.get(0);
           }
           return node;
         });
         return Aloha.bind('aloha-editable-created', function($event, editable) {
-          editable.obj.find('div.title:not(.aloha-block)').alohaBlock({
+          editable.obj.find('> div.title:not(.aloha-block)').alohaBlock({
             'aloha-block-type': 'TitleBlock'
           });
           if (editable.obj.is('.title-editor')) {


### PR DESCRIPTION
This avoids styling everything that is a title the same as the document title.
