### PR TITLE
Title wrapper fix

### DIFF
--- a/oerpub/index.html
+++ b/oerpub/index.html
@@ -91,7 +91,6 @@
                 // is one of the section heading tags
                 function getClosestHeadingParent(ele) {
                     while(ele != null) {
-                        console.log(ele);
                         if(ele.tagName && possibleHeadings.indexOf(ele.tagName.toUpperCase()) != -1) {
                             break;
                         }
@@ -101,7 +100,6 @@
                         }
                         ele = ele.parentNode;
                     }
-                    console.log(ele);
                     return ele;
                 }
 

--- a/src/plugins/oer/title/lib/title-plugin.coffee
+++ b/src/plugins/oer/title/lib/title-plugin.coffee
@@ -31,9 +31,8 @@ define [
       # Add a prune function that cleans up the title editor
       emap = Ephemera.ephemera().pruneFns.push (node) ->
         $node = $(node)
-        if $node.is('div.title') and $node.has('.title-editor').length
+        if $node.is('div.title') and $node.find('.title-editor').length
           $node.text($node.find('.title-editor').text())
-          return $node.get(0)
         node
 
       Aloha.bind 'aloha-editable-created', ($event, editable) ->

--- a/src/plugins/oer/title/lib/title-plugin.js
+++ b/src/plugins/oer/title/lib/title-plugin.js
@@ -22,9 +22,8 @@
         emap = Ephemera.ephemera().pruneFns.push(function(node) {
           var $node;
           $node = $(node);
-          if ($node.is('div.title') && $node.has('.title-editor').length) {
+          if ($node.is('div.title') && $node.find('.title-editor').length) {
             $node.text($node.find('.title-editor').text());
-            return $node.get(0);
           }
           return node;
         });


### PR DESCRIPTION
has() and find() behave slightly differently. For what I was doing with it, the result should have been the same, but it appears not to be the case. find() does the right thing though.

In addition, this merge drops two console.log lines. console.log breaks things when it runs on a browser without a console.
