### PR TITLE
A fix to toolbar plugin, and updates on oerpub editor page

### DIFF
--- a/oerpub/index.html
+++ b/oerpub/index.html
@@ -171,6 +171,12 @@
                                 $html.attr('xmlns:bib',  'http://bibtexml.sf.net/');
                                 $html.attr('xmlns:data', 'http://dev.w3.org/html5/spec/#custom');
 
+                                // Build simple header with title.
+                                var $head = $('<head />'),
+                                    title = editor.obj.find('>div.title').text();
+                                $('<title/>').text(title).appendTo($head);
+                                $html.append($head);
+
                                 var $body = $('<body />');
                                 $body.attr('class', 'content');
                                 $body.append(editor.getContents());

--- a/src/plugins/oer/toolbar/lib/toolbar-plugin.coffee
+++ b/src/plugins/oer/toolbar/lib/toolbar-plugin.coffee
@@ -1,6 +1,7 @@
 define [ 'jquery', 'aloha', 'aloha/plugin', 'ui/ui', 'PubSub' ], (
     jQuery, Aloha, Plugin, Ui, PubSub) ->
 
+  squirreledEditable = null
   $ROOT = jQuery('body') # Could also be configured to some other div
 
   makeItemRelay = (slot) ->
@@ -89,7 +90,6 @@ define [ 'jquery', 'aloha', 'aloha/plugin', 'ui/ui', 'PubSub' ], (
     init: ->
 
       toolbar = @
-      squirreledEditable = null
 
       changeHeading = (evt) ->
         $el = jQuery(@)

--- a/src/plugins/oer/toolbar/lib/toolbar-plugin.js
+++ b/src/plugins/oer/toolbar/lib/toolbar-plugin.js
@@ -2,7 +2,8 @@
 (function() {
 
   define(['jquery', 'aloha', 'aloha/plugin', 'ui/ui', 'PubSub'], function(jQuery, Aloha, Plugin, Ui, PubSub) {
-    var $ROOT, adoptedActions, makeItemRelay;
+    var $ROOT, adoptedActions, makeItemRelay, squirreledEditable;
+    squirreledEditable = null;
     $ROOT = jQuery('body');
     makeItemRelay = function(slot) {
       var ItemRelay;
@@ -131,9 +132,8 @@
 
     return Plugin.create("toolbar", {
       init: function() {
-        var changeHeading, squirreledEditable, toolbar;
+        var changeHeading, toolbar;
         toolbar = this;
-        squirreledEditable = null;
         changeHeading = function(evt) {
           var $el, $newEl, $oldEl, hTag, rangeObject;
           $el = jQuery(this);


### PR DESCRIPTION
In the toolbar, I belive squireledEditable was declared in the wrong scope. Also added a bit of JS code to the saving procedure in the oerpub editor page, which is reused as tal template in our editor product.
