### PR TITLE
squirreledEditable declared in wrong scope

### DIFF
--- a/src/plugins/oer/popover/lib/popover-plugin.coffee
+++ b/src/plugins/oer/popover/lib/popover-plugin.coffee
@@ -327,12 +327,12 @@ define 'popover', [ 'aloha', 'jquery' ], (Aloha, jQuery) ->
       $el = jQuery(rangeObject.getCommonAncestorContainer())
       $el = $el.parents(helper.selector) if not $el.is(helper.selector)
 
-      # Hide other tooltips of the same type
-      nodes = jQuery(Aloha.activeEditable.obj).find(helper.selector)
-      nodes = nodes.not($el)
-      nodes.trigger 'hide'
-
       if Aloha.activeEditable
+        # Hide other tooltips of the same type
+        nodes = jQuery(Aloha.activeEditable.obj).find(helper.selector)
+        nodes = nodes.not($el)
+        nodes.trigger 'hide'
+
         enteredLinkScope = selectionChangeHandler(rangeObject, helper.selector)
         if insideScope isnt enteredLinkScope
           insideScope = enteredLinkScope

--- a/src/plugins/oer/popover/lib/popover-plugin.js
+++ b/src/plugins/oer/popover/lib/popover-plugin.js
@@ -342,10 +342,10 @@ There are 3 variables that are stored on each element;
         if (!$el.is(helper.selector)) {
           $el = $el.parents(helper.selector);
         }
-        nodes = jQuery(Aloha.activeEditable.obj).find(helper.selector);
-        nodes = nodes.not($el);
-        nodes.trigger('hide');
         if (Aloha.activeEditable) {
+          nodes = jQuery(Aloha.activeEditable.obj).find(helper.selector);
+          nodes = nodes.not($el);
+          nodes.trigger('hide');
           enteredLinkScope = selectionChangeHandler(rangeObject, helper.selector);
           if (insideScope !== enteredLinkScope) {
             insideScope = enteredLinkScope;

--- a/src/plugins/oer/toolbar/lib/toolbar-plugin.coffee
+++ b/src/plugins/oer/toolbar/lib/toolbar-plugin.coffee
@@ -1,6 +1,7 @@
 define [ 'jquery', 'aloha', 'aloha/plugin', 'ui/ui', 'PubSub' ], (
     jQuery, Aloha, Plugin, Ui, PubSub) ->
 
+  squirreledEditable = null
   $ROOT = jQuery('body') # Could also be configured to some other div
 
   makeItemRelay = (slot) ->
@@ -89,7 +90,6 @@ define [ 'jquery', 'aloha', 'aloha/plugin', 'ui/ui', 'PubSub' ], (
     init: ->
 
       toolbar = @
-      squirreledEditable = null
 
       changeHeading = (evt) ->
         $el = jQuery(@)

--- a/src/plugins/oer/toolbar/lib/toolbar-plugin.coffee
+++ b/src/plugins/oer/toolbar/lib/toolbar-plugin.coffee
@@ -92,6 +92,7 @@ define [ 'jquery', 'aloha', 'aloha/plugin', 'ui/ui', 'PubSub' ], (
       toolbar = @
 
       changeHeading = (evt) ->
+        evt.preventDefault()
         $el = jQuery(@)
         hTag = $el.attr('data-tagname')
         rangeObject = Aloha.Selection.getRangeObject()
@@ -105,7 +106,6 @@ define [ 'jquery', 'aloha', 'aloha/plugin', 'ui/ui', 'PubSub' ], (
         $newEl = Aloha.jQuery(Aloha.Selection.getRangeObject().getCommonAncestorContainer())
         $newEl.addClass($oldEl.attr('class'))
         $newEl.bind 'click', headingFunc
-        evt.preventDefault()
         # $newEl.attr('id', $oldEl.attr('id))
         # Setting the id is commented because otherwise collaboration wouldn't register a change in the document
 

--- a/src/plugins/oer/toolbar/lib/toolbar-plugin.js
+++ b/src/plugins/oer/toolbar/lib/toolbar-plugin.js
@@ -2,7 +2,8 @@
 (function() {
 
   define(['jquery', 'aloha', 'aloha/plugin', 'ui/ui', 'PubSub'], function(jQuery, Aloha, Plugin, Ui, PubSub) {
-    var $ROOT, adoptedActions, makeItemRelay;
+    var $ROOT, adoptedActions, makeItemRelay, squirreledEditable;
+    squirreledEditable = null;
     $ROOT = jQuery('body');
     makeItemRelay = function(slot) {
       var ItemRelay;
@@ -131,9 +132,8 @@
 
     return Plugin.create("toolbar", {
       init: function() {
-        var changeHeading, squirreledEditable, toolbar;
+        var changeHeading, toolbar;
         toolbar = this;
-        squirreledEditable = null;
         changeHeading = function(evt) {
           var $el, $newEl, $oldEl, hTag, rangeObject;
           $el = jQuery(this);

--- a/src/plugins/oer/toolbar/lib/toolbar-plugin.js
+++ b/src/plugins/oer/toolbar/lib/toolbar-plugin.js
@@ -136,6 +136,7 @@
         toolbar = this;
         changeHeading = function(evt) {
           var $el, $newEl, $oldEl, hTag, rangeObject;
+          evt.preventDefault();
           $el = jQuery(this);
           hTag = $el.attr('data-tagname');
           rangeObject = Aloha.Selection.getRangeObject();
@@ -147,8 +148,7 @@
           $oldEl = Aloha.jQuery(rangeObject.getCommonAncestorContainer());
           $newEl = Aloha.jQuery(Aloha.Selection.getRangeObject().getCommonAncestorContainer());
           $newEl.addClass($oldEl.attr('class'));
-          $newEl.bind('click', headingFunc);
-          return evt.preventDefault();
+          return $newEl.bind('click', headingFunc);
         };
         $ROOT.on('click', '.action.changeHeading', changeHeading);
         Aloha.bind('aloha-editable-activated', function(event, data) {


### PR DESCRIPTION
The idea is that squirreledEditable is a global variable, here limited to the
plugin scope by requirejs, that helps us out during the times when
Aloha.activeEditable is misteriously cleared. Moving it to plugin scope appears
to be the correct fix then.
