### PR TITLE
Strip off the <html> envelope.

### DIFF
--- a/oerpub/index.html
+++ b/oerpub/index.html
@@ -247,7 +247,10 @@
                         // Fetch the preview
                         $('#statusmessage').data('message')('Loading preview...');
                         Aloha.jQuery.get(body_url, function(data){
-                            var $editable = Aloha.jQuery('#canvas').html(data);
+                            var d = document.createElement('html');
+                            d.innerHTML = data;
+                            var $editable = Aloha.jQuery('#canvas').html(
+                                $('body > *', d));
 
                             // Remove the pyramid debug toolbar from the preview
                             // if it exists. This code should do nothing in production


### PR DESCRIPTION
This prevents the title double-up issue accidentally introduced in pull request 29.
