### PR TITLE
When a popover is closed, clear insideScope

### DIFF
--- a/src/plugins/oer/popover/lib/popover-plugin.coffee
+++ b/src/plugins/oer/popover/lib/popover-plugin.coffee
@@ -322,7 +322,12 @@ define [ 'aloha', 'jquery' ], (Aloha, jQuery) ->
     Aloha.bind 'aloha-editable-deactivated', (event, data) ->
       helper.stopAll(data.editable)
       insideScope = false
-      enteredLinkScope = false
+
+    Aloha.bind 'aloha-editable-created', (evt, editable) ->
+      # When a popover is hidden, the next selection change should
+      # do the right thing.
+      editable.obj.on 'hidden-popover', helper.selector, () ->
+        insideScope = false
 
     Aloha.bind 'aloha-selection-changed', (event, rangeObject) ->
       # Hide all popovers except for the current one maybe?

--- a/src/plugins/oer/popover/lib/popover-plugin.js
+++ b/src/plugins/oer/popover/lib/popover-plugin.js
@@ -348,8 +348,12 @@ There are 3 variables that are stored on each element;
       });
       Aloha.bind('aloha-editable-deactivated', function(event, data) {
         helper.stopAll(data.editable);
-        insideScope = false;
-        return enteredLinkScope = false;
+        return insideScope = false;
+      });
+      Aloha.bind('aloha-editable-created', function(evt, editable) {
+        return editable.obj.on('hidden-popover', helper.selector, function() {
+          return insideScope = false;
+        });
       });
       Aloha.bind('aloha-selection-changed', function(event, rangeObject) {
         var $el, nodes;


### PR DESCRIPTION
insideScope remembers the item on which the popover is currently open. This
is used to determine, on selection change, whether a popover needs to be
opened. It needs to be cleared when a popover is closed, otherwise it becomes
impossible to open a popover on the same element immediately afterwards.
