### PR TITLE
Use jquery to process ajax loaded html

### DIFF
--- a/oerpub/index.html
+++ b/oerpub/index.html
@@ -253,10 +253,9 @@
                         // Fetch the preview
                         $('#statusmessage').data('message')('Loading preview...');
                         Aloha.jQuery.get(body_url, function(data){
-                            var d = document.createElement('html');
-                            d.innerHTML = data;
+                            var $d = Aloha.jQuery('<div />').html(data);
                             var $editable = Aloha.jQuery('#canvas').html(
-                                $('body > *', d));
+                                $d.find('> *'));
 
                             // Remove the pyramid debug toolbar from the preview
                             // if it exists. This code should do nothing in production


### PR DESCRIPTION
This deals better with xhtml. innerHTML does not deal with it at all well. This broke the media plugin which somehow ended up with an <iframe /> element in xml shorthand.
