### PR TITLE
Move mousedown handler to editor-created event.

### DIFF
--- a/src/plugins/oer/popover/lib/popover-plugin.coffee
+++ b/src/plugins/oer/popover/lib/popover-plugin.coffee
@@ -269,14 +269,8 @@ define [ 'aloha', 'jquery' ], (Aloha, jQuery) ->
 
               $node.data('aloha-bubble-timer', delayTimeout($node, 'hide', Popover.MILLISECS / 2)) if not $node.data('aloha-bubble-timer')
 
-      # Stop mousedown events inside a popover from propagating up to
-      # aloha, causing the editor to deactivate and the popover to close.
-      jQuery('body').off('mousedown.bubble', '.popover').on 'mousedown.bubble', '.popover', (evt) ->
-        evt.stopPropagation()
-
     stopAll: (editable) =>
       # Remove all event handlers and close all bubbles
-      jQuery('body').off 'mousedown.bubble', '.popover'
       $nodes = jQuery(editable.obj).find(@selector)
       this.stopOne($nodes)
       jQuery(editable.obj).off('.bubble', @selector)
@@ -324,6 +318,11 @@ define [ 'aloha', 'jquery' ], (Aloha, jQuery) ->
       insideScope = false
 
     Aloha.bind 'aloha-editable-created', (evt, editable) ->
+      # Stop mousedown events inside a popover from propagating up to
+      # aloha, causing the editor to deactivate and the popover to close.
+      jQuery('body').off('mousedown.bubble', '.popover').on 'mousedown.bubble', '.popover', (evt) ->
+        evt.stopPropagation()
+
       # When a popover is hidden, the next selection change should
       # do the right thing.
       editable.obj.on 'hidden-popover', helper.selector, () ->

--- a/src/plugins/oer/popover/lib/popover-plugin.js
+++ b/src/plugins/oer/popover/lib/popover-plugin.js
@@ -248,7 +248,7 @@ There are 3 variables that are stored on each element;
             return $node.removeData('aloha-bubble-visible');
           }
         });
-        $el.on('mouseenter.bubble', this.selector, function(evt) {
+        return $el.on('mouseenter.bubble', this.selector, function(evt) {
           var $node;
 
           $node = jQuery(evt.target);
@@ -283,15 +283,11 @@ There are 3 variables that are stored on each element;
             });
           }
         });
-        return jQuery('body').off('mousedown.bubble', '.popover').on('mousedown.bubble', '.popover', function(evt) {
-          return evt.stopPropagation();
-        });
       };
 
       Helper.prototype.stopAll = function(editable) {
         var $nodes;
 
-        jQuery('body').off('mousedown.bubble', '.popover');
         $nodes = jQuery(editable.obj).find(this.selector);
         this.stopOne($nodes);
         return jQuery(editable.obj).off('.bubble', this.selector);
@@ -351,6 +347,9 @@ There are 3 variables that are stored on each element;
         return insideScope = false;
       });
       Aloha.bind('aloha-editable-created', function(evt, editable) {
+        jQuery('body').off('mousedown.bubble', '.popover').on('mousedown.bubble', '.popover', function(evt) {
+          return evt.stopPropagation();
+        });
         return editable.obj.on('hidden-popover', helper.selector, function() {
           return insideScope = false;
         });


### PR DESCRIPTION
The way it was it would add and remove the mousedown handler multiple times (for each plugin that uses popovers). It seems a race condition then ensured that it wasn't added at all. With this change, it is added once when the editor is created and never removed.
