### PR TITLE
Move mousedown handler completely out of event handlers.

### DIFF
--- a/src/plugins/oer/popover/lib/popover-plugin.coffee
+++ b/src/plugins/oer/popover/lib/popover-plugin.coffee
@@ -168,6 +168,10 @@ define [ 'aloha', 'jquery' ], (Aloha, jQuery) ->
     proto.hide = Bootstrap_Popover_hide(proto.hide)
   monkeyPatch()
 
+  # Stop mousedown events inside a popover from propagating up to
+  # aloha, causing the editor to deactivate and the popover to close.
+  jQuery('body').on 'mousedown', '.popover', (evt) ->
+    evt.stopPropagation()
 
   Popover =
     MILLISECS: 2000
@@ -269,14 +273,8 @@ define [ 'aloha', 'jquery' ], (Aloha, jQuery) ->
 
               $node.data('aloha-bubble-timer', delayTimeout($node, 'hide', Popover.MILLISECS / 2)) if not $node.data('aloha-bubble-timer')
 
-      # Stop mousedown events inside a popover from propagating up to
-      # aloha, causing the editor to deactivate and the popover to close.
-      jQuery('body').off('mousedown.bubble', '.popover').on 'mousedown.bubble', '.popover', (evt) ->
-        evt.stopPropagation()
-
     stopAll: (editable) =>
       # Remove all event handlers and close all bubbles
-      jQuery('body').off 'mousedown.bubble', '.popover'
       $nodes = jQuery(editable.obj).find(@selector)
       this.stopOne($nodes)
       jQuery(editable.obj).off('.bubble', @selector)

--- a/src/plugins/oer/popover/lib/popover-plugin.js
+++ b/src/plugins/oer/popover/lib/popover-plugin.js
@@ -157,6 +157,9 @@ There are 3 variables that are stored on each element;
       return proto.hide = Bootstrap_Popover_hide(proto.hide);
     };
     monkeyPatch();
+    jQuery('body').on('mousedown', '.popover', function(evt) {
+      return evt.stopPropagation();
+    });
     Popover = {
       MILLISECS: 2000,
       MOVE_INTERVAL: 100,
@@ -248,7 +251,7 @@ There are 3 variables that are stored on each element;
             return $node.removeData('aloha-bubble-visible');
           }
         });
-        $el.on('mouseenter.bubble', this.selector, function(evt) {
+        return $el.on('mouseenter.bubble', this.selector, function(evt) {
           var $node;
 
           $node = jQuery(evt.target);
@@ -283,15 +286,11 @@ There are 3 variables that are stored on each element;
             });
           }
         });
-        return jQuery('body').off('mousedown.bubble', '.popover').on('mousedown.bubble', '.popover', function(evt) {
-          return evt.stopPropagation();
-        });
       };
 
       Helper.prototype.stopAll = function(editable) {
         var $nodes;
 
-        jQuery('body').off('mousedown.bubble', '.popover');
         $nodes = jQuery(editable.obj).find(this.selector);
         this.stopOne($nodes);
         return jQuery(editable.obj).off('.bubble', this.selector);


### PR DESCRIPTION
This fixes #409. The way it was it would add and remove the mousedown
handler multiple times (for each plugin/editor that uses popovers). It seems a race
condition then ensured that it wasn't added at all. With this change, it is
added once when the module is loaded.
