### PR TITLE
Avoid errors with undefined populator, selector

### DIFF
--- a/src/plugins/oer/popover/lib/popover-plugin.coffee
+++ b/src/plugins/oer/popover/lib/popover-plugin.coffee
@@ -328,9 +328,14 @@ define [ 'aloha', 'jquery' ], (Aloha, jQuery) ->
         insideScope = false
 
     Aloha.bind 'aloha-selection-changed', (event, rangeObject) ->
+      # How this is even possible I do not understand, but apparently it is
+      # possible for our helper to not be completely initialised at this point.
+      if not (helper.populator and helper.selector)
+        return
+
       # Hide all popovers except for the current one maybe?
       $el = jQuery(rangeObject.getCommonAncestorContainer())
-      $el = $el.parents(helper.selector) if not $el.is(helper.selector)
+      $el = $el.parents(helper.selector).eq(0) if not $el.is(helper.selector)
 
       if Aloha.activeEditable
         # Hide other tooltips of the same type
@@ -342,7 +347,7 @@ define [ 'aloha', 'jquery' ], (Aloha, jQuery) ->
         if insideScope isnt enteredLinkScope
           insideScope = enteredLinkScope
           if not $el.is(helper.selector)
-            $el = $el.parents(helper.selector)
+            $el = $el.parents(helper.selector).eq(0)
           if enteredLinkScope
             $el.trigger 'show'
             $el.data('aloha-bubble-selected', true)

--- a/src/plugins/oer/popover/lib/popover-plugin.js
+++ b/src/plugins/oer/popover/lib/popover-plugin.js
@@ -375,7 +375,6 @@ There are 3 variables that are stored on each element;
               $el = $el.parents(helper.selector).eq(0);
             }
             if (enteredLinkScope) {
-              console.log("selector is " + helper.selector);
               $el.trigger('show');
               $el.data('aloha-bubble-selected', true);
               $el.off('.bubble');

--- a/src/plugins/oer/popover/lib/popover-plugin.js
+++ b/src/plugins/oer/popover/lib/popover-plugin.js
@@ -357,9 +357,12 @@ There are 3 variables that are stored on each element;
       Aloha.bind('aloha-selection-changed', function(event, rangeObject) {
         var $el, nodes;
 
+        if (!(helper.populator && helper.selector)) {
+          return;
+        }
         $el = jQuery(rangeObject.getCommonAncestorContainer());
         if (!$el.is(helper.selector)) {
-          $el = $el.parents(helper.selector);
+          $el = $el.parents(helper.selector).eq(0);
         }
         if (Aloha.activeEditable) {
           nodes = jQuery(Aloha.activeEditable.obj).find(helper.selector);
@@ -369,9 +372,10 @@ There are 3 variables that are stored on each element;
           if (insideScope !== enteredLinkScope) {
             insideScope = enteredLinkScope;
             if (!$el.is(helper.selector)) {
-              $el = $el.parents(helper.selector);
+              $el = $el.parents(helper.selector).eq(0);
             }
             if (enteredLinkScope) {
+              console.log("selector is " + helper.selector);
               $el.trigger('show');
               $el.data('aloha-bubble-selected', true);
               $el.off('.bubble');


### PR DESCRIPTION
For reasons I could not determine, and which disappear whenever you add a
debugger to the mix (that is, it is a race condition), The populator and helper
members are sometimes undefined causing errors. In addition, this code makes
sure we don't get the entire hierarchy if more than one parent matches
the selector, for we most certainly don't want more than one popup.
